### PR TITLE
feat(linters): add stylelint new rules from frontend-guideline

### DIFF
--- a/packages/linters/src/stylelint.config.js
+++ b/packages/linters/src/stylelint.config.js
@@ -29,5 +29,6 @@ module.exports = {
     'declaration-block-single-line-max-declarations': 1,
     'declaration-block-semicolon-newline-after': 'always-multi-line',
     'rule-empty-line-before': 'always',
+    'length-zero-no-unit': true,
   },
 }


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/3957397225/views/89804814/pulses/5079904356)

#### What is being delivered?

- add rule to keep one declaration per line
- add rule to separate each ruleset by a blank line
- add rule to avoid specifying units is zero-values

#### What impacts?

This finish to translate the main rules about [frontend-guideline](https://github.com/juntossomosmais/frontend-guideline) to stylelint
