### PR TITLE
feat(linters): add rule to ensure commit messages are always lower-case

### DIFF
--- a/packages/linters/src/commitlint.config.js
+++ b/packages/linters/src/commitlint.config.js
@@ -17,6 +17,8 @@ module.exports = {
         'perf',
       ],
     ],
-    'body-case': [2, 'always', ['lower-case']],
+    "body-leading-blank": [2, "always"],
+    "subject-case": [2, "always", ["lower-case"]],
+    "header-max-length": [2, "always", 72],
   },
 }


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/1756815464/pulses/5210019538)

#### What is being delivered?

- Added rules [in this file](https://github.com/juntossomosmais/time-out-market/blob/main/packages/linters/src/commitlint.config.js).

#### What impacts?

We have [validations in our PRs now](https://juntossomosmais.slack.com/archives/C04NC3DM4JZ/p1695157617487639). One of the rules expects all the commit messages to be in lower-case and to avoid commits with messages out of this spec we are adding a rule so we catch inconsistencies locally before we actually commit.

#### Reversal plan

[Describe which plan we should follow if this delivery has to be reversed.](https://github.com/juntossomosmais/web-customer-typescript/wiki/Processo-para-reverter-Deploy)

#### Evidences

Media(images, gifs or videos) that shows the result of your work.
