### PR TITLE
feat(linters): remove revert option from commit list

### DIFF
--- a/packages/linters/src/commitlint.config.js
+++ b/packages/linters/src/commitlint.config.js
@@ -13,7 +13,6 @@ module.exports = {
         'refactor',
         'ci',
         'test',
-        'revert',
         'perf',
       ],
     ],


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/3957397225/views/89792005)

#### What is being delivered?

Removing revert option from commit list

#### What impacts?

As our git flow unallow `reverts`, it's valid to remove it from commit options

#### Reversal plan

reset

#### Evidences

Media(images, gifs or videos) that shows the result of your work.
