### PR TITLE
feat(linters): add padding-line-between-statements

### DIFF
--- a/packages/linters/src/eslint.config.js
+++ b/packages/linters/src/eslint.config.js
@@ -30,7 +30,10 @@ module.exports = {
     'prefer-const': 'error',
     'padding-line-between-statements': [
       'error',
+      { blankLine: 'always', prev: 'if', next: '*' },
       { blankLine: 'always', prev: '*', next: 'return' },
+      { blankLine: 'always', prev: '*', next: 'function' },
+      { blankLine: 'always', prev: 'function', next: '*' },
       { blankLine: 'always', prev: ['const', 'let', 'var'], next: '*' },
       {
         blankLine: 'any',


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/3957397225/pulses/5210669032)

#### What is being delivered?

- Add rules to `padding-line-between-statements` 

#### What impacts?

We were not requiring line breaking patterns between JavaScript elements, the purpose of this delivery is to add a convention about it

#### Reversal plan

Remove rule
