### PR TITLE
feat(linters): disable media-query-no-invalid

### DIFF
--- a/packages/linters/src/stylelint.config.styled.js
+++ b/packages/linters/src/stylelint.config.styled.js
@@ -1,4 +1,7 @@
 module.exports = {
   extends: ['./stylelint.config.js'],
   customSyntax: 'postcss-styled-syntax',
+  rules: {
+    'media-query-no-invalid': false,
+  },
 }


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Disable `media-query-no-invalid` in styled components rules

#### What impacts?

We have some custom media query rules inside our syled components files, the goal is to keep these custom rules without lint errors

#### Reversal plan

Remove rules
