### PR TITLE
feat(linters): add rules to jsx to react lint

### DIFF
--- a/packages/linters/src/eslint.config.react.js
+++ b/packages/linters/src/eslint.config.react.js
@@ -13,6 +13,8 @@ module.exports = {
     'react/display-name': 'off',
     'react/prop-types': 'off',
     'react/no-unescaped-entities': 'off',
+    'react/jsx-uses-react': 'on',
+    'react/react-in-jsx-scope': 'on',
   },
   settings: {
     react: {


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Add `'react/jsx-uses-react': 'on'`
- Add `'react/react-in-jsx-scope': 'on'`

#### What impacts?

Every time on saving file its automatically removing the React from the import, the target of this pull request is to fix this issue.

#### Reversal plan

Remove rules
