### PR TITLE
feat(linters): add rule to object-curly-spacing

### DIFF
--- a/packages/linters/src/eslint.config.js
+++ b/packages/linters/src/eslint.config.js
@@ -21,6 +21,7 @@ module.exports = {
   },
   rules: {
     eqeqeq: 2,
+    'object-curly-spacing': ['error', 'always'],
     'no-inline-comments': 2,
     'no-async-promise-executor': 2,
     'no-console': 2,


### PR DESCRIPTION
## Infos

#### What is being delivered?

- Add `'object-curly-spacing': ['error', 'always'],`

#### What impacts?

Add a new rule to avoid problems about linter to curly spacing
