### PR TITLE
ci: avoid error on unreleased merge

### DIFF
--- a/.github/workflows/release-and-publish-packages.yml
+++ b/.github/workflows/release-and-publish-packages.yml
@@ -70,6 +70,7 @@ jobs:
           npx nx show projects --affected
 
       - name: Build and publish affected packages
+        if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm run publish-package
         continue-on-error: false


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

avoiding [error](https://github.com/juntossomosmais/time-out-market/actions/runs/11668636727/job/32488756174#step:10:7) on unreleased merge (the merge which triggers a releasable merge)

#### What impacts?

no errors on merge

#### Reversal plan

Describe which plan we should follow if this delivery has to be reversed.

#### Evidences

Media(images, gifs or videos) that shows the result of your work.
