### PR TITLE
ci: avoid error unreleased merge

### DIFF
--- a/.github/workflows/release-and-publish-packages.yml
+++ b/.github/workflows/release-and-publish-packages.yml
@@ -70,6 +70,7 @@ jobs:
           npx nx show projects --affected
 
       - name: Build and publish affected packages
+        if: ${{ steps.release.outputs.releases_created }}
         run: |
           npm run publish-package
         continue-on-error: false

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npx nx run-many --target=test --parallel",
     "test:ci": "npx nx affected --target=test:ci --base=origin/main --parallel",
     "test:ci-merge": "npx nx affected --target=test:ci --base=origin/main~1 --head=origin/main --parallel",
-    "publish-package": "npx nx affected --target=publish-package --base=origin/main~1 --head=origin/main --parallel"
+    "publish-package": "npx nx affected --target=publish-package --base=HEAD~1 --head=HEAD --parallel"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Infos

[Task](https://juntossomosmais.monday.com/boards/XXX/pulses/XXX)

#### What is being delivered?

- adding again this [change](https://github.com/juntossomosmais/time-out-market/pull/269) after git reset
- also using HEAD as reference instead of main because of [this](https://github.com/juntossomosmais/time-out-market/actions/runs/11672269810/job/32500502840#step:10:19) error (copilot suggestion :robot: )

#### What impacts?

no errors on merge

#### Reversal plan

Describe which plan we should follow if this delivery has to be reversed.

#### Evidences

- avoid the errors on unreleased merge

https://github.com/juntossomosmais/time-out-market/pull/269#issuecomment-2455293585

- running `npx nx affected --target=publish-package --base=HEAD~1 --head=HEAD --parallel` locally

![Screenshot from 2024-11-04 18-01-11](https://github.com/user-attachments/assets/c09fdcb3-8113-4f9d-bb62-32e0875bd9fc)

