### PR TITLE
feat(linters): enabling scss-specific at-rule validation

### DIFF
--- a/packages/linters/src/stylelint.config.js
+++ b/packages/linters/src/stylelint.config.js
@@ -7,6 +7,8 @@ module.exports = {
     '@juntossomosmais/linters/stylelint/plugins/use-zindex-tokens.js',
   ],
   rules: {
+    'at-rule-no-unknown': null,
+    'scss/at-rule-no-unknown': true,
     'order/order': ['custom-properties', 'declarations'],
     'no-descending-specificity': null,
     'order/properties-alphabetical-order': true,


### PR DESCRIPTION
## Summary

This pull request includes a configuration update to the Stylelint rules in the `stylelint.config.js` file. The most important changes include allowing unknown at-rules and enabling SCSS-specific at-rule validation.

Stylelint configuration updates:

* [`packages/linters/src/stylelint.config.js`](diffhunk://#diff-344524a4084389cbe666ce48c4cb892c17d64ca54c2c2eb58a06a49a41d82e1bR10-R11): Added rule to allow unknown at-rules by setting `at-rule-no-unknown` to `null`.
* [`packages/linters/src/stylelint.config.js`](diffhunk://#diff-344524a4084389cbe666ce48c4cb892c17d64ca54c2c2eb58a06a49a41d82e1bR10-R11): Enabled SCSS-specific at-rule validation by setting `scss/at-rule-no-unknown` to `true`.