### PR TITLE
feat(http-front-cache): implement cache removal functionality

### DIFF
--- a/packages/http-front-cache/src/lib/cache-factory.spec.ts
+++ b/packages/http-front-cache/src/lib/cache-factory.spec.ts
@@ -138,14 +138,17 @@ describe('cacheFactory', () => {
 
   it('Should remove the cache when removeCacheByParam is called and call the service function again', async () => {
     await cachedServiceFunction(defaultParams)
-    const cachedEntry = mockProvider.getItem(defaultHashedParams)
+    let cachedEntry = mockProvider.getItem(defaultHashedParams)
 
     expect(mockServiceFunction).toHaveBeenCalledTimes(1)
     expect(cachedEntry).not.toBeNull()
+    expect(cachedEntry).not.toBeUndefined()
+
     removeCacheByParam(mockProvider, defaultParams)
+    cachedEntry = mockProvider.getItem(defaultHashedParams)
     await cachedServiceFunction(defaultParams)
     expect(mockServiceFunction).toHaveBeenCalledTimes(2)
-    expect(cachedEntry).toBeNull()
+    expect(cachedEntry).toBeUndefined()
   })
 
   it('should not set data in the cache if the service function throws an error', async () => {

--- a/packages/http-front-cache/src/lib/cache-factory.spec.ts
+++ b/packages/http-front-cache/src/lib/cache-factory.spec.ts
@@ -137,6 +137,8 @@ describe('cacheFactory', () => {
   })
 
   it('Should remove the cache when removeCacheByParam is called and call the service function again', async () => {
+    expect(removeCacheByParam(mockProvider, defaultParams)).toBeNull()
+
     await cachedServiceFunction(defaultParams)
     let cachedEntry = mockProvider.getItem(defaultHashedParams)
 

--- a/packages/http-front-cache/src/lib/cache-on-session-storage.spec.ts
+++ b/packages/http-front-cache/src/lib/cache-on-session-storage.spec.ts
@@ -1,6 +1,8 @@
 import * as cacheFactory from './cache-factory'
 import { cacheOnSessionStorage } from './cache-on-session-storage'
 import { sessionStorageProvider } from './providers/session-storage'
+import { removeCacheByParam } from './remove-cache-by-param'
+import { removeCacheByParamOnSessionStorage } from './remove-cache-by-param-session-storage'
 
 jest.mock('./providers/session-storage.ts', () => ({
   sessionStorageProvider: {
@@ -9,6 +11,10 @@ jest.mock('./providers/session-storage.ts', () => ({
     removeItem: jest.fn(),
     clear: jest.fn(),
   },
+}))
+
+jest.mock('./remove-cache-by-param', () => ({
+  removeCacheByParam: jest.fn(),
 }))
 
 const cacheFactoryMock = jest.spyOn(cacheFactory, 'cacheFactory')
@@ -26,6 +32,19 @@ describe('cacheOnSessionStorage', () => {
       expire,
       serviceFunction,
       provider: sessionStorageProvider,
+    })
+  })
+
+  describe('removeCacheByParamOnSessionStorage', () => {
+    it('should call removeCacheByParam with sessionStorageProvider', () => {
+      const params = ['test']
+
+      removeCacheByParamOnSessionStorage(...params)
+
+      expect(removeCacheByParam).toHaveBeenCalledWith(
+        sessionStorageProvider,
+        ...params
+      )
     })
   })
 })

--- a/packages/http-front-cache/src/lib/remove-cache-by-param-session-storage.ts
+++ b/packages/http-front-cache/src/lib/remove-cache-by-param-session-storage.ts
@@ -1,0 +1,12 @@
+import { sessionStorageProvider } from './providers/session-storage'
+import { removeCacheByParam } from './remove-cache-by-param'
+
+/**
+ * Delete the cache on sessionStorage by param (where param is the same param provided to the serviceFunction)
+ * @param params: the parameters that will be used find the cache key (hash)
+ */
+export const removeCacheByParamOnSessionStorage = (
+  ...params: unknown[]
+): void | null => {
+  removeCacheByParam(sessionStorageProvider, ...params)
+}

--- a/packages/http-front-cache/src/lib/remove-cache-by-param.ts
+++ b/packages/http-front-cache/src/lib/remove-cache-by-param.ts
@@ -1,0 +1,22 @@
+import hash from 'object-hash'
+
+import { Provider } from './types'
+
+/**
+ * Delete cache by param (where param is the same param provided to the serviceFunction)
+ * @param params: the parameters that will be used find the cache key (hash)
+ * @param provider: the provider used to store the cache (such as in-memory, session storage, etc)
+ */
+export const removeCacheByParam = (
+  provider: Provider,
+  ...params: unknown[]
+): void | null => {
+  const key = hash(params)
+  const cachedEntry = provider.getItem(key)
+
+  if (!cachedEntry) {
+    return null
+  }
+
+  provider.removeItem(key)
+}


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/1757192123/pulses/9820932900)

## Summary

This pull request adds new functionality for removing cached entries by their parameters, improving cache management and test coverage for both generic providers and session storage. The main changes introduce two new utility functions, `removeCacheByParam` and `removeCacheByParamOnSessionStorage`, along with corresponding unit tests to ensure their correct behavior.

### New cache removal utilities

* Added `removeCacheByParam` function to allow deletion of cached entries by their parameters for any provider, using a hash of the parameters as the cache key. (`packages/http-front-cache/src/lib/remove-cache-by-param.ts`)
* Added `removeCacheByParamOnSessionStorage` function, which wraps `removeCacheByParam` for use specifically with the `sessionStorageProvider`. (`packages/http-front-cache/src/lib/remove-cache-by-param-session-storage.ts`)

### Test coverage improvements

* Added a new test to `cache-factory.spec.ts` verifying that cached entries are removed and the service function is called again when `removeCacheByParam` is invoked. (`packages/http-front-cache/src/lib/cache-factory.spec.ts`)
* Added a test suite to `cache-on-session-storage.spec.ts` for `removeCacheByParamOnSessionStorage`, ensuring it correctly delegates to `removeCacheByParam` with the session storage provider. (`packages/http-front-cache/src/lib/cache-on-session-storage.spec.ts`)

### Test setup updates

* Updated test imports and mocks to include the new cache removal utilities in both `cache-factory.spec.ts` and `cache-on-session-storage.spec.ts`. [[1]](diffhunk://#diff-9a0c01b2d8dccc3a12269adc4a2d2d5291d07a831f3b1b68dcf41969acedf1f4R3-R5) [[2]](diffhunk://#diff-e2c7b84a4e9bae7e4b27c24ed4595a6a8556bc2c7c6be9698be888c765cd2a9bR4-R5) [[3]](diffhunk://#diff-e2c7b84a4e9bae7e4b27c24ed4595a6a8556bc2c7c6be9698be888c765cd2a9bR16-R19)

## Evidences

Media(images, gifs or videos) that shows the result of your work.
