### PR TITLE
feat(linters): add unicorn rules to flat config base

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18428,6 +18428,7 @@
         "eslint-import-resolver-typescript": ">= 3",
         "eslint-plugin-import": ">= 2",
         "eslint-plugin-sonarjs": ">= 1",
+        "eslint-plugin-unicorn": ">= 56",
         "postcss": ">= 8",
         "postcss-scss": ">= 4",
         "postcss-styled-syntax": ">= 0.4",

--- a/packages/linters/package.json
+++ b/packages/linters/package.json
@@ -28,6 +28,7 @@
     "eslint-import-resolver-typescript": ">= 3",
     "eslint-plugin-import": ">= 2",
     "eslint-plugin-sonarjs": ">= 1",
+    "eslint-plugin-unicorn": ">= 56",
     "postcss-scss": ">= 4",
     "postcss-styled-syntax": ">= 0.4",
     "postcss": ">= 8",

--- a/packages/linters/src/eslint-config/flat/base.mjs
+++ b/packages/linters/src/eslint-config/flat/base.mjs
@@ -2,6 +2,7 @@ import js from '@eslint/js'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import importPlugin from 'eslint-plugin-import'
 import sonarjs from 'eslint-plugin-sonarjs'
+import unicorn from 'eslint-plugin-unicorn'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
 
@@ -107,6 +108,18 @@ export default [
 
   // Prettier config
   eslintConfigPrettier,
+
+  // Unicorn — idiomatic JS/TS best practices
+  {
+    name: '@jsm/eslint-config/unicorn',
+    plugins: { unicorn },
+    rules: {
+      'unicorn/no-negated-condition': 'error',
+      'unicorn/prefer-array-some': 'error',
+      'unicorn/prefer-number-properties': 'error',
+      'unicorn/prefer-string-replace-all': 'error',
+    },
+  },
 
   // SonarJS config
   {


### PR DESCRIPTION
## Summary

Moves enforcement of four rules documented in the project's frontend coding guidelines (`frontend/*.md`) from project-level ESLint config into the shared `@juntossomosmais/linters` flat config base, so all consuming projects benefit automatically.

## Rules moved from docs to lint

| Rule | Plugin | Source doc | Was |
|------|--------|-----------|-----|
| `unicorn/prefer-number-properties` | `eslint-plugin-unicorn` | `javascript.md` — _"Use \`Number.parseInt\`, \`Number.isNaN\`, \`Number.isFinite\` — never global equivalents"_ | docs only |
| `unicorn/prefer-string-replace-all` | `eslint-plugin-unicorn` | `javascript.md` — _"Use \`.replaceAll()\` — not \`.replace()\` with \`/g\` flag"_ | docs only |
| `unicorn/prefer-array-some` | `eslint-plugin-unicorn` | `javascript.md` — _"Use \`.some()\` for boolean checks — not \`.find()\`"_ | docs only |
| `unicorn/no-negated-condition` | `eslint-plugin-unicorn` | `javascript.md` — _"Avoid negated conditions in ternaries"_ | docs only |

## Changes

- `packages/linters/src/eslint-config/flat/base.mjs` — new `@jsm/eslint-config/unicorn` config block
- `packages/linters/package.json` — `eslint-plugin-unicorn >= 56` added to `peerDependencies`

## Consuming projects

Projects using the flat config (`@juntossomosmais/linters/eslint-config/flat/base.mjs`) must install `eslint-plugin-unicorn` as a dev dependency. No changes needed to their ESLint config — rules are inherited from the base.

## Test plan

- [ ] Install `eslint-plugin-unicorn` in a consuming project and confirm the four rules fire on known violations
- [ ] Confirm no rule conflicts with existing config blocks in consuming projects

🤖 Generated with [Claude Code](https://claude.com/claude-code)