### PR TITLE
fix(rupture-scss): resolve below()/to-width() via $rupture.scale-names

### DIFF
--- a/packages/rupture-scss/rupture.scss
+++ b/packages/rupture-scss/rupture.scss
@@ -555,6 +555,7 @@ $default-scale-names: 'xs' 's' 'm' 'l' 'xl' 'hd';
     // instead of a hardcoded name list, so consumers' custom scales are honored.
     $index: _get-scale-number($scale-point);
     $scale: map.get($rupture, scale);
+    // Clamp to the last scale entry if _get-scale-number()'s fallback (2/3/4) overshoots a short custom scale.
     $max-width-value: if(
       $index <= list.length($scale),
       list.nth($scale, $index),

--- a/packages/rupture-scss/rupture.scss
+++ b/packages/rupture-scss/rupture.scss
@@ -550,35 +550,25 @@ $default-scale-names: 'xs' 's' 'm' 'l' 'xl' 'hd';
   $use-device-width: map.get($rupture, use-device-width),
   $fallback-class: null
 ) {
-  // Special handling for predefined breakpoint names
   @if meta.type-of($scale-point) == 'string' {
-    // Get concrete pixel values based on breakpoint names
-    $max-width-value: null;
+    // Resolve the named breakpoint via the configured $rupture.scale-names / $rupture.scale
+    // instead of a hardcoded name list, so consumers' custom scales are honored.
+    $index: _get-scale-number($scale-point);
+    $scale: map.get($rupture, scale);
+    $max-width-value: if(
+      $index <= list.length($scale),
+      list.nth($scale, $index),
+      list.nth($scale, list.length($scale))
+    );
 
-    // Direct mapping of named breakpoints to pixel values
-    // Use the breakpoint directly from our project values
-    @if $scale-point == 'xsmall' {
-      $max-width-value: 575px; // one less than $screen-xs
-    } @else if $scale-point == 'small' {
-      $max-width-value: 767px; // one less than $screen-sm
-    } @else if $scale-point == 'medium' {
-      $max-width-value: 991px; // one less than $screen-md
-    } @else if $scale-point == 'large' {
-      $max-width-value: 1279px; // one less than $screen-lg
-    } @else if $scale-point == 'xlarge' {
-      $max-width-value: 1439px; // one less than $screen-xlg
-    } @else if $scale-point == 'xxlarge' {
-      $max-width-value: 1919px; // one less than $screen-fhd
-    } @else if $scale-point == 'xxxlarge' {
-      $max-width-value: 2047px; // one less than $screen-2k
-    } @else if $scale-point == 'desktop2k' {
-      $max-width-value: 3839px; // one less than $screen-4k
-    } @else {
-      // Default to small if no match
-      $max-width-value: 767px;
+    @if $anti-overlap != null {
+      $max-width-value: _adjust-overlap(
+        $anti-overlap,
+        $max-width-value,
+        $side: 'max'
+      );
     }
 
-    // Generate the media query with the resolved width
     @media only screen and (max-width: #{$max-width-value}) {
       @content;
     }


### PR DESCRIPTION
[Task](https://juntossomosmais.monday.com/boards/5143488854/views/113762127/pulses/12137231359)

## Summary

`to-width()` (the implementation behind `below()`) resolved string breakpoint names via a hardcoded `@if/else` over `'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | 'xxlarge' | 'xxxlarge' | 'desktop2k'`, falling through to `767px` for any unknown name. This ignored both `$rupture.scale` and `$rupture.scale-names`, so any consumer with a custom scale (e.g. `'mobile' | 'tablet' | 'desktop'` as used in `web-customer-typescript`) got `max-width: 767px` regardless of which name they passed.

Concretely, with the project scale `0 576px 768px 992px 1200px ...` and names `'0' 'mobile' 'tablet' 'desktop' 'desktopL' ...`, the bug meant:

| Call | Expected | Before fix |
| --- | --- | --- |
| `below(mobile)` | `max-width: 575px` | `max-width: 767px` |
| `below(desktop)` | `max-width: 991px` | `max-width: 767px` |
| `below(desktopL)` | `max-width: 1199px` | `max-width: 767px` |

`above()` and `between()` were unaffected — they already resolve names dynamically via `_get-scale-number()` and `list.nth(map.get($rupture, scale), ...)`.

### Change
- Replace the hardcoded list in `@mixin to-width` with a dynamic lookup that mirrors `between()`'s `$max` handling: resolve the name via the existing `_get-scale-number()` helper, then read the pixel value from `$rupture.scale` at that index.
- Apply anti-overlap via the existing `_adjust-overlap(..., $side: 'max')` helper, which is a no-op for negative shifts on the `min` side — so `above()` continues to emit `min-width: $breakpoint` (no off-by-one).
- The existing numeric branch (`meta.type-of($scale-point) == 'number'`) and the catch-all `@include between(1, ...)` fallback are untouched.

Net diff: -26 / +16 lines.

### Behavior change note
Consumers who happened to call `below('small' | 'medium' | 'large' | ...)` against the **default** `$rupture` map will now get a different value, because those names are no longer hardcoded — they go through `_get-scale-number()`'s alias fallback (index 2/3/4 etc. into the default scale `0 400px 600px 800px 1050px 1800px`). The old hardcoded values (`767`, `991`, `1279`, ...) corresponded to a specific project's breakpoints and were never documented in the README, so this aligns implementation with the documented configuration-driven API.

## Evidences

Verified by compiling a fixture with `sass` against the modified file, using the standard project scale (`0 576 768 992 1200 1440 1920 2048 3840`) and `anti-overlap: -1px`:

```scss
@use 'rupture' with ($rupture: (
  scale:       0 576px 768px 992px 1200px 1440px 1920px 2048px 3840px,
  scale-names: '0' 'mobile' 'tablet' 'desktop' 'desktopL' 'desktopXL' 'fullHD' '2K' '4K',
  anti-overlap: -1px,
));

.bm  { @include rupture.below(mobile)    { color: red; } }
.bt  { @include rupture.below(tablet)    { color: red; } }
.bd  { @include rupture.below(desktop)   { color: red; } }
.bdl { @include rupture.below(desktopL)  { color: red; } }
.am  { @include rupture.above(mobile)    { color: blue; } }
.at  { @include rupture.above(tablet)    { color: blue; } }
.btw { @include rupture.between(tablet, desktop) { color: green; } }
```

Compiled output:

```css
@media only screen and (max-width: 575px)  { .bm  { color: red;  } }
@media only screen and (max-width: 767px)  { .bt  { color: red;  } }
@media only screen and (max-width: 991px)  { .bd  { color: red;  } }
@media only screen and (max-width: 1199px) { .bdl { color: red;  } }
@media only screen and (min-width: 576px)  { .am  { color: blue; } }
@media only screen and (min-width: 768px)  { .at  { color: blue; } }
@media only screen and (min-width: 768px) and (max-width: 1199px) { .btw { color: green; } }
```

All values match the documented expectations.

### Context

Surfaced while migrating `web-customer-typescript` to consume `@juntossomosmais/rupture-scss` instead of a hand-rolled `_breakpoints.scss` — see https://github.com/juntossomosmais/web-customer-typescript/pull/9655#issuecomment-4430428011.

🤖 Generated with [Claude Code](https://claude.com/claude-code)