### PR TITLE
fix(linters): resolve code smells and lift coverage

### DIFF
--- a/packages/linters/jest.config.js
+++ b/packages/linters/jest.config.js
@@ -5,7 +5,12 @@ module.exports = {
   coverageDirectory: 'coverage',
   coverageReporters: ['lcov', 'text', 'text-summary'],
   coveragePathIgnorePatterns: ['/node_modules/'],
-  collectCoverageFrom: ['src/stylelint/**', '!dist/**', '!**/node_modules/**'],
+  collectCoverageFrom: [
+    'src/stylelint/**',
+    'src/eslint-config/**',
+    '!dist/**',
+    '!**/node_modules/**',
+  ],
   coverageThreshold: {
     global: {
       lines: 80,

--- a/packages/linters/sonar-project.properties
+++ b/packages/linters/sonar-project.properties
@@ -5,6 +5,7 @@ sonar.sources=.
 
 sonar.test.inclusions=\
 **/*.spec.js,\
+**/*.spec.mjs,\
 **/*.spec.ts
 sonar.exclusions=\
 node_modules/**,\
@@ -19,6 +20,7 @@ src/stylelint.config.styled.js,\
 jest.config.js,\
 **/*.spec.js,\
 **/*.spec.jsx,\
+**/*.spec.mjs,\
 **/*.spec.ts,\
 **/*.spec.tsx,\
 **/.md

--- a/packages/linters/src/eslint-config/flat/__tests__/base.spec.mjs
+++ b/packages/linters/src/eslint-config/flat/__tests__/base.spec.mjs
@@ -1,0 +1,104 @@
+import base from '../base.mjs'
+
+describe('eslint-config/flat/base', () => {
+  it('should export a non-empty array of flat configs', () => {
+    expect(Array.isArray(base)).toBe(true)
+    expect(base.length).toBeGreaterThan(0)
+  })
+
+  it('should declare a global ignores entry covering node_modules, dist, and .next', () => {
+    const ignoresEntry = base.find((entry) => Array.isArray(entry.ignores))
+
+    expect(ignoresEntry).toBeDefined()
+    expect(ignoresEntry.ignores).toEqual(
+      expect.arrayContaining([
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/.next/**',
+      ])
+    )
+  })
+
+  it('should expose the expected named configs', () => {
+    const names = base.map((entry) => entry.name).filter(Boolean)
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        '@eslint/js/recommended',
+        '@jsm/eslint-config/imports',
+        '@jsm/eslint-config/typescript',
+        'sonarjs/recommended',
+      ])
+    )
+  })
+
+  it('should configure the typescript block for ts, tsx, mts, cts, and vue files', () => {
+    const tsEntry = base.find(
+      (entry) => entry.name === '@jsm/eslint-config/typescript'
+    )
+
+    expect(tsEntry).toBeDefined()
+    expect(tsEntry.files).toEqual(
+      expect.arrayContaining([
+        '**/*.ts',
+        '**/*.tsx',
+        '**/*.mts',
+        '**/*.cts',
+        '**/*.vue',
+      ])
+    )
+    expect(tsEntry.plugins).toHaveProperty('@typescript-eslint')
+    expect(tsEntry.rules['@typescript-eslint/no-explicit-any']).toBe(2)
+    expect(tsEntry.rules['@typescript-eslint/no-unused-vars']).toEqual([
+      2,
+      { varsIgnorePattern: '^h$' },
+    ])
+  })
+
+  it('should pin the javascript block rules required by the guideline', () => {
+    const jsEntry = base.find(
+      (entry) => entry.name === '@eslint/js/recommended'
+    )
+
+    expect(jsEntry).toBeDefined()
+    expect(jsEntry.rules.eqeqeq).toBe(2)
+    expect(jsEntry.rules['no-console']).toBe(2)
+    expect(jsEntry.rules['prefer-const']).toBe(2)
+    expect(jsEntry.rules['object-curly-spacing']).toEqual(['error', 'always'])
+    expect(jsEntry.languageOptions.ecmaVersion).toBe('latest')
+    expect(jsEntry.languageOptions.sourceType).toBe('module')
+  })
+
+  it('should sort imports asc and case-insensitive with newlines between groups', () => {
+    const importsEntry = base.find(
+      (entry) => entry.name === '@jsm/eslint-config/imports'
+    )
+
+    expect(importsEntry).toBeDefined()
+    const [severity, options] = importsEntry.rules['import/order']
+
+    expect(severity).toBe(2)
+    expect(options['newlines-between']).toBe('always')
+    expect(options.alphabetize).toEqual({
+      order: 'asc',
+      caseInsensitive: true,
+    })
+    expect(options.groups).toEqual([
+      'builtin',
+      'external',
+      'internal',
+      'parent',
+      'sibling',
+      'index',
+    ])
+  })
+
+  it('should exclude spec and test files from the sonarjs block', () => {
+    const sonarEntry = base.find((entry) => entry.name === 'sonarjs/recommended')
+
+    expect(sonarEntry).toBeDefined()
+    expect(sonarEntry.ignores).toEqual(
+      expect.arrayContaining(['**/*.spec.*', '**/*.test.*'])
+    )
+  })
+})

--- a/packages/linters/src/eslint-config/flat/__tests__/react.spec.mjs
+++ b/packages/linters/src/eslint-config/flat/__tests__/react.spec.mjs
@@ -1,0 +1,47 @@
+import base from '../base.mjs'
+import react from '../react.mjs'
+
+describe('eslint-config/flat/react', () => {
+  it('should export a non-empty array of flat configs', () => {
+    expect(Array.isArray(react)).toBe(true)
+    expect(react.length).toBeGreaterThan(0)
+  })
+
+  it('should compose every base entry before adding the react block', () => {
+    expect(react.length).toBe(base.length + 1)
+    base.forEach((entry, index) => {
+      expect(react[index]).toBe(entry)
+    })
+  })
+
+  it('should expose a named react block with react and react-hooks plugins', () => {
+    const reactEntry = react.find(
+      (entry) => entry.name === '@jsm/eslint-config/react'
+    )
+
+    expect(reactEntry).toBeDefined()
+    expect(reactEntry.plugins).toHaveProperty('react')
+    expect(reactEntry.plugins).toHaveProperty('react-hooks')
+  })
+
+  it('should enable jsx parsing in languageOptions', () => {
+    const reactEntry = react.find(
+      (entry) => entry.name === '@jsm/eslint-config/react'
+    )
+
+    expect(reactEntry.languageOptions.parserOptions.ecmaFeatures.jsx).toBe(true)
+  })
+
+  it('should configure the rules required by the guideline', () => {
+    const reactEntry = react.find(
+      (entry) => entry.name === '@jsm/eslint-config/react'
+    )
+
+    expect(reactEntry.rules['react/display-name']).toBe(0)
+    expect(reactEntry.rules['react/prop-types']).toBe(0)
+    expect(reactEntry.rules['react/no-unescaped-entities']).toBe(0)
+    expect(reactEntry.rules['react/jsx-uses-react']).toBe(1)
+    expect(reactEntry.rules['react/react-in-jsx-scope']).toBe(1)
+    expect(reactEntry.rules['react/jsx-boolean-value']).toEqual([2, 'always'])
+  })
+})

--- a/packages/linters/src/eslint-config/flat/base.mjs
+++ b/packages/linters/src/eslint-config/flat/base.mjs
@@ -1,4 +1,5 @@
 import js from '@eslint/js'
+import { defineConfig } from 'eslint/config'
 import eslintConfigPrettier from 'eslint-config-prettier'
 import importPlugin from 'eslint-plugin-import'
 import sonarjs from 'eslint-plugin-sonarjs'
@@ -86,7 +87,7 @@ export default [
   },
 
   // TypeScript config
-  ...tseslint.config({
+  ...defineConfig({
     name: '@jsm/eslint-config/typescript',
     files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts', '**/*.vue'],
     plugins: {

--- a/packages/linters/src/stylelint/plugins/use-tokens.js
+++ b/packages/linters/src/stylelint/plugins/use-tokens.js
@@ -31,7 +31,7 @@ const compiledTokenChecks = Object.entries(tokens)
   .map(([tokenName, tokenValue]) => {
     const alias = tokens[tokenValue]
     const valuePattern = alias ? `${tokenValue}|#${alias}` : tokenValue
-    const pattern = `(^|\\s)(${valuePattern})(\\s|;|$)`
+    const pattern = String.raw`(^|\s)(${valuePattern})(\s|;|$)`
 
     return {
       tokenName,

--- a/packages/linters/src/stylelint/plugins/use-zindex-tokens.js
+++ b/packages/linters/src/stylelint/plugins/use-zindex-tokens.js
@@ -44,9 +44,9 @@ const ruleFunction = (primaryOption) => {
     root.walkDecls((decl) => {
       if (decl.prop !== 'z-index') return
 
-      const zIndexValue = parseInt(decl.value, 10)
+      const zIndexValue = Number.parseInt(decl.value, 10)
 
-      if (!isNaN(zIndexValue)) {
+      if (!Number.isNaN(zIndexValue)) {
         const tokenName = zIndexTokenMap.get(String(zIndexValue))
 
         if (tokenName) {


### PR DESCRIPTION
## Summary

Closes the sonarqube quality gate failures on the `linters` package:

### Code smells fixed

| File | Issue | Fix |
| --- | --- | --- |
| \`src/eslint-config/flat/base.mjs:89\` | \`tseslint.config(...)\` overload is deprecated in typescript-eslint | Switched to \`defineConfig()\` from \`eslint/config\` (ESLint 10 core helper, same \`extends\` semantics). |
| \`src/stylelint/plugins/use-tokens.js:34\` | Avoidable backslash escaping in regex source | Use \`String.raw\` template tag. |
| \`src/stylelint/plugins/use-zindex-tokens.js:47\` | Prefer \`Number.parseInt\` | Swapped global \`parseInt\` for \`Number.parseInt\`. |
| \`src/stylelint/plugins/use-zindex-tokens.js:49\` | Prefer \`Number.isNaN\` | Swapped global \`isNaN\` for \`Number.isNaN\`. |

### Coverage on new code

The previous quality gate failed with **57.8% coverage on new code** because \`src/eslint-config/flat/base.mjs\` and \`src/eslint-config/flat/react.mjs\` (added during the ESLint v10 migration) had no tests.

- Added \`__tests__/base.spec.mjs\` — 7 cases validating shape, named blocks, ignores, ts/import/sonarjs configuration, and rule severities.
- Added \`__tests__/react.spec.mjs\` — 5 cases validating composition over \`base\`, plugin registration, JSX parsing, and rule severities.
- Extended \`jest.config.js\` \`collectCoverageFrom\` to also include \`src/eslint-config/**\` so the lcov report consumed by Sonar covers the new directory.

## Verification

```bash
npx nx run @juntossomosmais/linters:test:ci
```

Tests:       32 passed, 32 total
Statements:  100% (374/374)
Lines:       100% (374/374)
Functions:   100%  (6/6)
Branches:    97.43% (38/39)

```
npx nx run-many -t build  # http-front-cache + rupture-scss ✅
```


🤖 Generated with [Claude Code](https://claude.com/claude-code)