### PR TITLE
fix(linters): use eslint-plugin-import-x on flat config

### DIFF
--- a/docs/architecture-decision-records/202605-tooling-dependency-compatibility.md
+++ b/docs/architecture-decision-records/202605-tooling-dependency-compatibility.md
@@ -49,7 +49,8 @@ We maintain a strict **Dependency Compatibility Matrix** that documents version 
 | Package | Version | Constraint | Reason | Related To |
 |---------|---------|------------|---------|------------|
 | **eslint-plugin-sonarjs** | `^4.0.3` | v4.x | Flat config support | ESLint |
-| **eslint-plugin-import** | `^2.32.0` | v2.x | Used by the flat base for `import/order` | ESLint |
+| **eslint-plugin-import-x** | `^4.16.2` | v4.x | Used by the flat base for `import-x/order`. Replaces `eslint-plugin-import` on the flat path because the original plugin still calls `SourceCode#getTokenOrCommentAfter`, removed in ESLint v10 | ESLint |
+| **eslint-plugin-import** | `^2.32.0` | v2.x | Kept for the published legacy eslintrc exports only (`src/eslint.config.js`); not used by the flat base | ESLint |
 | **eslint-plugin-react** | `^7.37.5` | v7.x | Used by the flat React config | ESLint, React |
 | **eslint-plugin-react-hooks** | `^7.1.1` | v7.x | Used by the flat React config | ESLint, React |
 | **eslint-config-prettier** | `^10.1.8` | v10.x | Disables formatting rules that conflict with Prettier | ESLint, Prettier |
@@ -179,7 +180,8 @@ These scenarios require extra caution:
 |----------|------|
 | ESLint v8/v9 install | Not supported. The `eslint` peer dependency is `>=10`; consumers must upgrade to v10 |
 | ESLint v10 + legacy `.eslintrc.*` | Not supported. ESLint v10 only loads flat config; consumers must migrate to `eslint.config.*` |
-| `eslint-plugin-import` / `eslint-plugin-react` on ESLint v10 | Their declared peer ranges may lag behind v10. Verify lint runs end to end after upgrades |
+| `eslint-plugin-import` on ESLint v10 (flat path) | Not supported. v2.32.0 still calls `SourceCode#getTokenOrCommentAfter`, removed in ESLint v10; the flat base uses `eslint-plugin-import-x` instead |
+| `eslint-plugin-react` on ESLint v10 | Declared peer range may lag behind v10. Verify lint runs end to end after upgrades |
 
 ## Consequences
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-import-resolver-node": "^0.4.0",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-sonarjs": "^4.0.3",
@@ -3643,6 +3644,13 @@
         "win32"
       ]
     },
+    "node_modules/@package-json/types": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@package-json/types/-/types-0.0.12.tgz",
+      "integrity": "sha512-uu43FGU34B5VM9mCNjXCwLaGHYjXdNincqKLaraaCW+7S2+SmiBg1Nv8bPnmschrIfZmfKNY9f3fC376MRrObw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@phenomnomnominal/tsquery": {
       "version": "6.2.0",
       "dev": true,
@@ -6248,6 +6256,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/compare-func": {
       "version": "2.0.0",
       "dev": true,
@@ -7215,6 +7233,57 @@
       },
       "peerDependencies": {
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.2.tgz",
+      "integrity": "sha512-rM9K8UBHcWKpzQzStn1YRN2T5NvdeIfSVoKu/lKF41znQXHAUcBbYXe5wd6GNjZjTrP7viQ49n1D83x/2gYgIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@package-json/types": "^0.0.12",
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
@@ -14772,7 +14841,7 @@
     },
     "packages/http-front-cache": {
       "name": "@juntossomosmais/http-front-cache",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "object-hash": "^3.0.0",
         "pako": "^2.1.0"
@@ -14784,17 +14853,18 @@
     },
     "packages/linters": {
       "name": "@juntossomosmais/linters",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "peerDependencies": {
         "@commitlint/cli": ">=21",
         "@commitlint/config-conventional": ">=21",
         "@juntossomosmais/atomium-tokens": ">=2",
         "@typescript-eslint/eslint-plugin": ">=8",
         "@typescript-eslint/parser": ">=8",
-        "eslint": ">=8.57",
+        "eslint": ">=10",
         "eslint-import-resolver-babel-plugin-root-import": ">= 1",
         "eslint-import-resolver-typescript": ">=4",
         "eslint-plugin-import": ">= 2",
+        "eslint-plugin-import-x": ">=4",
         "eslint-plugin-sonarjs": ">=4",
         "postcss": ">= 8",
         "postcss-scss": ">= 4",
@@ -14804,6 +14874,14 @@
         "stylelint-config-recommended": ">=18",
         "stylelint-config-standard-scss": ">=17",
         "stylelint-order": ">=8"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
       }
     },
     "packages/rupture-scss": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "eslint-import-resolver-node": "^0.4.0",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-sonarjs": "^4.0.3",

--- a/packages/linters/README.md
+++ b/packages/linters/README.md
@@ -46,6 +46,8 @@ npm i @juntossomosmais/atomium-tokens
 npm i -D @eslint/js globals eslint-plugin-import-x eslint-plugin-react eslint-plugin-react-hooks eslint-config-prettier typescript-eslint
 ```
 
+> **Upgrading from a previous version?** Replace `eslint-plugin-import` with `eslint-plugin-import-x` and rename any `import/order` rule overrides in your local config to `import-x/order`.
+
 Then install the linters package:
 
 ```bash

--- a/packages/linters/README.md
+++ b/packages/linters/README.md
@@ -43,7 +43,7 @@ npm i -D @commitlint/cli @commitlint/config-conventional prettier postcss stylel
 npm i @juntossomosmais/atomium-tokens
 
 # If you are using ESLint Flat config:
-npm i -D @eslint/js globals eslint-plugin-react eslint-plugin-react-hooks eslint-config-prettier typescript-eslint
+npm i -D @eslint/js globals eslint-plugin-import-x eslint-plugin-react eslint-plugin-react-hooks eslint-config-prettier typescript-eslint
 ```
 
 Then install the linters package:
@@ -138,7 +138,7 @@ export default [
 ]
 ```
 
-If you are using custom groups of `import/order` rules with Flat config, you can use the following configs example:
+If you are using custom groups of `import-x/order` rules with Flat config, you can use the following configs example:
 
 ```js
 import config from '@juntossomosmais/linters/eslint-config/flat/base.mjs'
@@ -149,10 +149,10 @@ export default [
   ...config,
   {
     rules: {
-      'import/order': [
+      'import-x/order': [
         'error',
         {
-          ...importsConfig.rules['import/order'][1],
+          ...importsConfig.rules['import-x/order'][1],
           groups: ['builtin', 'external', 'internal', 'parent'],
           'newlines-between': 'always',
           pathGroups: [

--- a/packages/linters/package.json
+++ b/packages/linters/package.json
@@ -27,6 +27,7 @@
     "eslint-import-resolver-babel-plugin-root-import": ">= 1",
     "eslint-import-resolver-typescript": ">=4",
     "eslint-plugin-import": ">= 2",
+    "eslint-plugin-import-x": ">=4",
     "eslint-plugin-sonarjs": ">=4",
     "postcss-scss": ">= 4",
     "postcss-styled-syntax": ">=0.7",
@@ -36,5 +37,13 @@
     "stylelint-config-standard-scss": ">=17",
     "stylelint-order": ">=8",
     "stylelint": ">=17"
+  },
+  "peerDependenciesMeta": {
+    "eslint-plugin-import": {
+      "optional": true
+    },
+    "eslint-plugin-import-x": {
+      "optional": true
+    }
   }
 }

--- a/packages/linters/src/eslint-config/flat/__tests__/base.spec.mjs
+++ b/packages/linters/src/eslint-config/flat/__tests__/base.spec.mjs
@@ -75,7 +75,7 @@ describe('eslint-config/flat/base', () => {
     )
 
     expect(importsEntry).toBeDefined()
-    const [severity, options] = importsEntry.rules['import/order']
+    const [severity, options] = importsEntry.rules['import-x/order']
 
     expect(severity).toBe(2)
     expect(options['newlines-between']).toBe('always')

--- a/packages/linters/src/eslint-config/flat/base.mjs
+++ b/packages/linters/src/eslint-config/flat/base.mjs
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
 import { defineConfig } from 'eslint/config'
 import eslintConfigPrettier from 'eslint-config-prettier'
-import importPlugin from 'eslint-plugin-import-x'
+import importXPlugin from 'eslint-plugin-import-x'
 import sonarjs from 'eslint-plugin-sonarjs'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
@@ -62,7 +62,7 @@ export default [
   // Imports config
   {
     name: '@jsm/eslint-config/imports',
-    plugins: { 'import-x': importPlugin },
+    plugins: { 'import-x': importXPlugin },
     rules: {
       'import-x/order': [
         2,
@@ -93,7 +93,7 @@ export default [
     plugins: {
       '@typescript-eslint': tseslint.plugin,
     },
-    extends: [importPlugin.flatConfigs.typescript],
+    extends: [importXPlugin.flatConfigs.typescript],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {

--- a/packages/linters/src/eslint-config/flat/base.mjs
+++ b/packages/linters/src/eslint-config/flat/base.mjs
@@ -1,7 +1,7 @@
 import js from '@eslint/js'
 import { defineConfig } from 'eslint/config'
 import eslintConfigPrettier from 'eslint-config-prettier'
-import importPlugin from 'eslint-plugin-import'
+import importPlugin from 'eslint-plugin-import-x'
 import sonarjs from 'eslint-plugin-sonarjs'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
@@ -62,9 +62,9 @@ export default [
   // Imports config
   {
     name: '@jsm/eslint-config/imports',
-    plugins: { import: importPlugin },
+    plugins: { 'import-x': importPlugin },
     rules: {
-      'import/order': [
+      'import-x/order': [
         2,
         {
           groups: [
@@ -93,7 +93,7 @@ export default [
     plugins: {
       '@typescript-eslint': tseslint.plugin,
     },
-    extends: [importPlugin.configs.typescript],
+    extends: [importPlugin.flatConfigs.typescript],
     languageOptions: {
       parser: tseslint.parser,
       parserOptions: {


### PR DESCRIPTION
## Why

`eslint-plugin-import@2.32.0` calls `SourceCode#getTokenOrCommentAfter`, which **ESLint v10 removed**. Any flat-config consumer hits a `TypeError` as soon as `import/order` tries to compute an autofix. This blocks the Phase 2 (atomium) consumer migration the moment unsorted imports are encountered.

`eslint-plugin-import-x` is the maintained fork with explicit ESLint v10 support and a near drop-in flat config API.

## Changes

- `packages/linters/src/eslint-config/flat/base.mjs`: import from `eslint-plugin-import-x`, register under the `import-x` plugin namespace, extend `importPlugin.flatConfigs.typescript`, rename the rule to `import-x/order`.
- `packages/linters/package.json`: add `eslint-plugin-import-x` as an optional peer alongside the existing `eslint-plugin-import` peer (kept for the published legacy eslintrc exports).
- Root `package.json`: add `eslint-plugin-import-x` for self-lint.
- `packages/linters/src/eslint-config/flat/__tests__/base.spec.mjs`: assert on the new rule key.
- README + ADR: document the swap and the v10 incompatibility.

## Verification

- `packages/linters` Jest suite: **32/32 passing**, 100% statements / 100% lines.
- Root `npm run lint`: clean.
- Manual smoke: a file with unsorted imports under flat config now reports `import-x/order` correctly and `eslint --fix` reorders them without crashing.

## Consumer impact

Downstream flat-config consumers must:

1. Install `eslint-plugin-import-x` instead of (or alongside) `eslint-plugin-import`.
2. Rename any local overrides that referenced the rule from `import/order` to `import-x/order`.

Legacy eslintrc consumers are unaffected: the published `src/eslint.config.js` still uses `eslint-plugin-import`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)