### PR TITLE
fix(linters): make flat react config work with eslint v10 consumers

### DIFF
--- a/packages/linters/src/eslint-config/flat/__tests__/react.spec.mjs
+++ b/packages/linters/src/eslint-config/flat/__tests__/react.spec.mjs
@@ -1,7 +1,27 @@
+import { Linter } from 'eslint'
+
 import base from '../base.mjs'
 import react from '../react.mjs'
 
 describe('eslint-config/flat/react', () => {
+  // Regression: eslint-plugin-react-hooks v6 changed `configs.recommended` to
+  // an array, which the previous spread injected as numeric keys, breaking
+  // ESLint v10 with `ConfigError: Unexpected key "0"`. v7 changed it again
+  // to a nested `configs.flat.recommended`. This test runs the actual ESLint
+  // engine so future shape changes surface as a test failure, not in a
+  // consumer repo.
+  it('should be accepted by the ESLint engine without ConfigError', () => {
+    const linter = new Linter({ configType: 'flat' })
+
+    expect(() =>
+      linter.verify(
+        'const Foo = () => null\nexport default Foo\n',
+        react,
+        { filename: 'foo.tsx' }
+      )
+    ).not.toThrow()
+  })
+
   it('should export a non-empty array of flat configs', () => {
     expect(Array.isArray(react)).toBe(true)
     expect(react.length).toBeGreaterThan(0)
@@ -41,7 +61,7 @@ describe('eslint-config/flat/react', () => {
     expect(reactEntry.rules['react/prop-types']).toBe(0)
     expect(reactEntry.rules['react/no-unescaped-entities']).toBe(0)
     expect(reactEntry.rules['react/jsx-uses-react']).toBe(1)
-    expect(reactEntry.rules['react/react-in-jsx-scope']).toBe(1)
+    expect(reactEntry.rules['react/react-in-jsx-scope']).toBe(0)
     expect(reactEntry.rules['react/jsx-boolean-value']).toEqual([2, 'always'])
   })
 })

--- a/packages/linters/src/eslint-config/flat/react.mjs
+++ b/packages/linters/src/eslint-config/flat/react.mjs
@@ -3,6 +3,21 @@ import reactHooks from 'eslint-plugin-react-hooks'
 
 import base from './base.mjs'
 
+// eslint-plugin-react-hooks ships incompatible config shapes across majors.
+// v7 exposes `configs.flat.recommended` (a flat-config object). v6 exposes
+// `configs['flat/recommended']` (an array containing one flat block); spreading
+// that array into an object literal injects numeric keys and breaks ESLint v10
+// with `ConfigError: Unexpected key "0"`. v5 exposes `configs.recommended` as
+// an eslintrc-style object with `plugins`/`rules`. Normalise to a single block.
+const reactHooksFlatConfig =
+  reactHooks.configs?.flat?.recommended ??
+  reactHooks.configs?.['flat/recommended'] ??
+  reactHooks.configs?.recommended ??
+  {}
+const reactHooksBlock = Array.isArray(reactHooksFlatConfig)
+  ? (reactHooksFlatConfig[0] ?? {})
+  : reactHooksFlatConfig
+
 /**
  * @type {Array<import('eslint').Linter.Config>}
  */
@@ -12,7 +27,7 @@ export default [
     name: '@jsm/eslint-config/react',
     ...react.configs.flat.recommended,
     ...react.configs.flat['jsx-runtime'],
-    ...reactHooks.configs.recommended,
+    ...reactHooksBlock,
     plugins: {
       react: react,
       'react-hooks': reactHooks,
@@ -30,7 +45,9 @@ export default [
       'react/prop-types': 0,
       'react/no-unescaped-entities': 0,
       'react/jsx-uses-react': 1,
-      'react/react-in-jsx-scope': 1,
+      // Off by default: modern JSX transform (React 17+, Next.js 12+) makes
+      // the explicit React import unnecessary.
+      'react/react-in-jsx-scope': 0,
       'react/jsx-boolean-value': [2, 'always'],
     },
   },


### PR DESCRIPTION
## Why

The flat React config (\`eslint-config/flat/react.mjs\`) crashes with \`ConfigError: Unexpected key \"0\"\` on ESLint v10 whenever a consumer installs \`eslint-plugin-react-hooks@^6\`. v6 changed \`configs.recommended\` from an object to an array, and the existing spread injected numeric keys into the config block. This blocks every Next.js / React consumer that bumps to ESLint v10 (v5 of the plugin declares an \`eslint <=9\` peer, so the bump is unavoidable).

It was not caught by CI because the existing tests only assert on the static shape of the exported config; they never instantiated ESLint with it.

## What

- **Normalise the react-hooks block across v5 / v6 / v7.** v7 ships \`configs.flat.recommended\` (object), v6 ships \`configs['flat/recommended']\` (array of one block), v5 ships \`configs.recommended\` (eslintrc-style object). The patch picks whichever exists and flattens an array down to its first entry before spreading.
- **Disable \`react/react-in-jsx-scope\` by default.** Modern JSX transform (React 17+, Next.js 12+) makes the explicit React import unnecessary, and downstream React consumers were overriding it locally already. Setting the default to off avoids the redundant override.
- **Add a regression test that runs the ESLint engine.** \`Linter#verify\` is called against the exported config so future plugin shape changes surface as a unit test failure rather than only in consumer repos.

## Verification

```
NODE_OPTIONS='--experimental-vm-modules' npx jest
```

5 suites, 33 tests pass. Coverage stays at 99.74% statements / 88.37% branches.

Also verified end-to-end by patching the file into a downstream Next.js consumer's \`node_modules\` and confirming \`npx eslint .\` runs without ConfigError.

## Release

release-please should ship this as \`0.25.2\`.