### PR TITLE
ci(repo): modernize deprecated actions in ci workflows

### DIFF
--- a/.github/workflows/release-and-publish-packages.yml
+++ b/.github/workflows/release-and-publish-packages.yml
@@ -20,25 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      # release-type and monorepo tagging are configured in release-please-config.json
+      - uses: googleapis/release-please-action@v5
         with:
-          command: manifest
-          monorepo-tags: true
           token: ${{ secrets.GITHUB_TOKEN }}
         id: release
 
       - name: Checkout Repository
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/checkout@v6
         with:
           ref: main
 
       - name: Setup pnpm
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -47,29 +46,29 @@ jobs:
           scope: '@juntossomosmais'
 
       - name: Authenticate with the GitHub Package Registry
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: |
           echo "@juntossomosmais:registry=https://npm.pkg.github.com" >> .npmrc
           echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" >> .npmrc
 
       - name: Install dependencies
-        if: ${{ steps.release.outputs.releases_created }}
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
         run: pnpm install --frozen-lockfile
 
       - name: Build and publish @juntossomosmais/linters
-        if: ${{ steps.release.outputs['packages/linters--release_created'] }}
+        if: ${{ steps.release.outputs['packages/linters--release_created'] == 'true' }}
         run: pnpm exec nx run @juntossomosmais/linters:publish-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish @juntossomosmais/http-front-cache
-        if: ${{ steps.release.outputs['packages/http-front-cache--release_created'] }}
+        if: ${{ steps.release.outputs['packages/http-front-cache--release_created'] == 'true' }}
         run: pnpm exec nx run @juntossomosmais/http-front-cache:publish-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish @juntossomosmais/rupture-scss
-        if: ${{ steps.release.outputs['packages/rupture-scss--release_created'] }}
+        if: ${{ steps.release.outputs['packages/rupture-scss--release_created'] == 'true' }}
         run: pnpm exec nx run rupture-scss:publish-package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -75,9 +75,8 @@ jobs:
 
       - name: SonarCloud Scan - Linters 🚨
         if: env.COVERAGE_LINTERS == 'true'
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: packages/linters/
@@ -89,9 +88,8 @@ jobs:
 
       - name: SonarCloud Scan - http-front-cache 🚨
         if: env.COVERAGE_HTTP_FRONT_CACHE == 'true'
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: packages/http-front-cache/

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,7 @@
 {
   "prerelease": false,
+  "release-type": "node",
+  "include-component-in-tag": true,
   "packages": {
     "packages/linters": {},
     "packages/http-front-cache": {},


### PR DESCRIPTION
## Summary

### release-please: `google-github-actions/release-please-action@v3` → `googleapis/release-please-action@v5`

- The `command: manifest` and `monorepo-tags` inputs were removed in v4+; manifest mode is now the default and config lives in `release-please-config.json`
- `release-type: node` added to the config (v3 defaulted it; v4+ requires it in the config)
- `include-component-in-tag: true` set explicitly: the default changed to `false` in v4, which would have broken the existing `linters-vX.Y.Z` / `http-front-cache-vX.Y.Z` / `rupture-scss-vX.Y.Z` tag scheme
- Publish conditions changed from truthy checks to `== 'true'`: v4+ always sets outputs as strings, so `if: ${{ outputs.releases_created }}` would be truthy even when the value is `'false'` and publish steps would run on every push
- Kept `GITHUB_TOKEN`: the PAT recommendation only applies if CI checks must trigger on release PRs, matching current v3 behavior (no change)

### SonarCloud: `sonarsource/sonarcloud-github-action@master` → `SonarSource/sonarqube-scan-action@v8`

- The sonarcloud action was deprecated and merged into `sonarqube-scan-action`
- `projectBaseDir` unchanged for both scans (linters, http-front-cache)
- `GITHUB_TOKEN` env dropped: the new action only needs `SONAR_TOKEN` for SonarQube Cloud

### Audit

All other actions already pinned to current majors: `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v6`.

## Validation

- Workflow YAML parses cleanly; config validated against the release-please schema
- `release-please@17.6.0` (exact version bundled in action v5) dry-run against this branch: resolves all three components and current versions from the component-prefixed tags, correctly reports nothing to release

## Test plan

- [ ] SonarCloud scan runs and decorates this PR
- [ ] After merge: release-please opens the next release PR with correct versions and tags
- [ ] After merging a release PR: packages publish to GitHub Packages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)